### PR TITLE
EA-2785: Improve responses

### DIFF
--- a/api/src/integration-test/java/eu/europeana/fulltextwrite/web/FulltextWriteControllerIT.java
+++ b/api/src/integration-test/java/eu/europeana/fulltextwrite/web/FulltextWriteControllerIT.java
@@ -145,4 +145,40 @@ class FulltextWriteControllerIT extends BaseIntegrationTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
   }
+
+  @Test
+  void submissionWithMissingRequestBodyShouldReturn400() throws Exception {
+    mockMvc
+        .perform(
+            post("/presentation/08604/FDE2205EEE384218A8D986E5138F9691/annopage")
+                .param(WebConstants.REQUEST_VALUE_MEDIA, "https://www.filmportal.de/node/1197365")
+                .param(WebConstants.REQUEST_VALUE_LANG, "nl")
+                .param(
+                    WebConstants.REQUEST_VALUE_RIGHTS,
+                    "http://creativecommons.org/licenses/by-sa/4.0/")
+                .accept(MediaType.APPLICATION_JSON)
+            // no contentType
+            )
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void submissionWithInvalidRequestParamShouldReturn400() throws Exception {
+    String requestBody = IntegrationTestUtils.loadFile(SUBTITLE_VTT);
+
+    mockMvc
+        .perform(
+            post("/presentation/08604/FDE2205EEE384218A8D986E5138F9691/annopage")
+                .param(WebConstants.REQUEST_VALUE_MEDIA, "https://www.filmportal.de/node/1197365")
+                .param(WebConstants.REQUEST_VALUE_LANG, "nl")
+                // originalLang is boolean
+                .param(WebConstants.REQUEST_VALUE_ORIGINAL_LANG, "nl")
+                .param(
+                    WebConstants.REQUEST_VALUE_RIGHTS,
+                    "http://creativecommons.org/licenses/by-sa/4.0/")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(CONTENT_TYPE_VTT)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+  }
 }

--- a/api/src/main/java/eu/europeana/fulltextwrite/config/WebMvcConfig.java
+++ b/api/src/main/java/eu/europeana/fulltextwrite/config/WebMvcConfig.java
@@ -1,6 +1,7 @@
 package eu.europeana.fulltextwrite.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -19,6 +20,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         .allowedMethods("*")
         .allowedHeaders("*")
         .allowCredentials(false)
+        .exposedHeaders(HttpHeaders.ALLOW)
         .maxAge(1000L); // in seconds
   }
 

--- a/api/src/main/java/eu/europeana/fulltextwrite/web/FulltextWriteExceptionHandler.java
+++ b/api/src/main/java/eu/europeana/fulltextwrite/web/FulltextWriteExceptionHandler.java
@@ -1,7 +1,56 @@
 package eu.europeana.fulltextwrite.web;
 
+import eu.europeana.api.commons.error.EuropeanaApiErrorResponse;
+import eu.europeana.api.commons.error.EuropeanaApiErrorResponse.Builder;
 import eu.europeana.api.commons.error.EuropeanaGlobalExceptionHandler;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @ControllerAdvice
-public class FulltextWriteExceptionHandler extends EuropeanaGlobalExceptionHandler {}
+public class FulltextWriteExceptionHandler extends EuropeanaGlobalExceptionHandler {
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<EuropeanaApiErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e, HttpServletRequest httpRequest) {
+    HttpStatus responseStatus = HttpStatus.BAD_REQUEST;
+
+    EuropeanaApiErrorResponse response =
+        new Builder(httpRequest, e, this.stackTraceEnabled())
+            .setStatus(responseStatus.value())
+            .setError(responseStatus.getReasonPhrase())
+            // e.getMessage() includes stacktrace
+            .setMessage("Required request body is missing")
+            .build();
+
+    return ResponseEntity.status(responseStatus)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(response);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<EuropeanaApiErrorResponse> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e, HttpServletRequest httpRequest) {
+    HttpStatus responseStatus = HttpStatus.BAD_REQUEST;
+
+    String errorMessage =
+        String.format(
+            "'%s' should be of type %s",
+            e.getName(), e.getParameter().getGenericParameterType().getTypeName());
+    EuropeanaApiErrorResponse response =
+        new Builder(httpRequest, e, this.stackTraceEnabled())
+            .setStatus(responseStatus.value())
+            .setError(responseStatus.getReasonPhrase())
+            .setMessage(errorMessage)
+            .build();
+
+    return ResponseEntity.status(responseStatus)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(response);
+  }
+}


### PR DESCRIPTION
- add `Access-Control-Expose-Headers: Allow` header
- return 400 when request body is missing and param types are invalid